### PR TITLE
feat: support Windows style EOL `\r\n`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,8 @@
 
 ### Added
 
-- Run tests in Windows and MacOS in GitHub actions.
+- Run tests on Windows and MacOS in GitHub actions.
+- Support Windows style line endings (`\r\n`).
 
 ## [v1.0.0] - 2023-05-07
 

--- a/src/SphinxInventoryParser.php
+++ b/src/SphinxInventoryParser.php
@@ -108,7 +108,7 @@ class SphinxInventoryParser
 		$versionStr = $this->ffgets($this->stream, 32);
 		$result = sscanf($versionStr, '# Sphinx inventory version %d', $header->version);
 		if ($result !== 1) {
-			$str = substr($versionStr, 0, -1);
+			$str = rtrim($versionStr, "\n\r");
 			throw new UnexpectedValueException("first line is not a valid Sphinx inventory version string: '$str'");
 		}
 		switch($header->version) {
@@ -124,22 +124,22 @@ class SphinxInventoryParser
 	 */
 	protected function parseHeaderV2(SphinxInventoryHeader $header): SphinxInventoryHeader {
 		$projectStr = $this->ffgets($this->stream);
-		$result = preg_match('/# Project: (.*)/', $projectStr, $matches);
+		$result = preg_match('/(*ANYCRLF)# Project: (.*)/', $projectStr, $matches);
 		if ($result !== 1) {
-			$str = substr($projectStr, 0, -1);
+			$str = rtrim($projectStr, "\n\r");
 			throw new UnexpectedValueException("second line is not a valid Project string: '$str'");
 		}
 		$header->projectName = $matches[1];
 		$versionStr = $this->ffgets($this->stream);
-		$result = preg_match('/# Version: (.*)/', $versionStr, $matches);
+		$result = preg_match('/(*ANYCRLF)# Version: (.*)/', $versionStr, $matches);
 		if ($result !== 1) {
-			$str = substr($versionStr, 0, -1);
+			$str = rtrim($versionStr, "\n\r");
 			throw new UnexpectedValueException("third line is not a valid Version string: '$str'");
 		}
 		$header->projectVersion = $matches[1];
 		$zlibStr = $this->ffgets($this->stream);
 		if (strpos($zlibStr, 'zlib') === false) {
-			$str = substr($zlibStr, 0, -1);
+			$str = rtrim($zlibStr, "\n\r");
 			throw new UnexpectedValueException("fourth line does advertise zlib compression: '$str'");
 		}
 		// We need to set window to 15 because PHP's zlib.inflate filter
@@ -181,12 +181,12 @@ class SphinxInventoryParser
 	 */
 	protected function parseObjectsV2(string $baseURI): Generator {
 		while(($objectStr = fgets($this->stream)) !== false) {
-			if (strlen($objectStr) == 1 || $objectStr[0] == '#') {
+			if (trim($objectStr) == '' || $objectStr[0] == '#') {
 				continue;
 			}
-			$result = preg_match('/(?x)(.+?)\s+([^\s:]+):(\S+)\s+(-?\d+)\s+?(\S*)\s+(.*)/', $objectStr, $matches);
+			$result = preg_match('/(*ANYCRLF)(?x)(.+?)\s+([^\s:]+):(\S+)\s+(-?\d+)\s+?(\S*)\s+(.*)/', $objectStr, $matches);
 			if ($result !== 1) {
-				$str = substr($objectStr, 0, -1);
+				$str = rtrim($objectStr, "\n\r");
 				throw new UnexpectedValueException("object string did not match pattern: '$str'");
 			}
 			array_shift($matches);

--- a/tests/SphinxInventoryParserTest.php
+++ b/tests/SphinxInventoryParserTest.php
@@ -40,13 +40,34 @@ final class SphinxInventoryParserTest extends TestCase
 		$this->assertCount(0, $inventory->objects);
 	}
 
-	public function testParseSkippedLines(): void
+	/**
+	 * @dataProvider skippedLinesProvider
+	 */
+	public function testParseSkippedLines(string $file): void
 	{
-		$stream = fopen(__DIR__ . '/data/skipped_lines.inv', 'r');
+		$stream = fopen(__DIR__ . '/data/' . $file, 'r');
 		$parser = new SphinxInventoryParser($stream);
 		$inventory = $parser->parse();
 		fclose($stream);
+		$this->assertEquals('CLUB1', $inventory->project);
+		$this->assertEquals('main', $inventory->version);
 		$this->assertCount(1, $inventory->objects);
+		$first = $inventory->objects[0];
+		$this->assertEquals('valid', $first->name);
+		$this->assertEquals('std', $first->domain);
+		$this->assertEquals('object', $first->role);
+		$this->assertEquals(1, $first->priority);
+		$this->assertEquals('line', $first->uri);
+		$this->assertEquals('valid', $first->displayName);
+	}
+
+	public function skippedLinesProvider(): array
+	{
+		return [
+			['skipped_lines.inv'],
+			['skipped_lines_lf.inv'],
+			['skipped_lines_crlf.inv'],
+		];
 	}
 
 	public function testParseNameWhitespace(): void

--- a/tests/SphinxInventoryParserTest.php
+++ b/tests/SphinxInventoryParserTest.php
@@ -90,7 +90,7 @@ final class SphinxInventoryParserTest extends TestCase
 	{
 		return [
 			["empty.inv", "unexpected end of file"],
-			["invalid_sphinx.inv", "first line is not a valid Sphinx inventory version string: '# Invalid Sphinx inventory ver'"],
+			["invalid_sphinx.inv", "first line is not a valid Sphinx inventory version string: '# Invalid Sphinx inventory vers'"],
 			["unsupported_inventory_version.inv", "unsupported Sphinx inventory version: 0"],
 			["invalid_project.inv", "second line is not a valid Project string: '# Invalid Project: CLUB1'"],
 			["invalid_version.inv", "third line is not a valid Version string: '# Invalid Version: 42'"],

--- a/tests/data/.gitattributes
+++ b/tests/data/.gitattributes
@@ -1,3 +1,1 @@
-*.header	text eol=lf
-*.data		text eol=lf
 *.inv		binary

--- a/tests/data/.gitattributes
+++ b/tests/data/.gitattributes
@@ -1,1 +1,3 @@
+*_crlf.*	text eol=crlf
+*_lf.*		text eol=lf
 *.inv		binary

--- a/tests/data/.gitignore
+++ b/tests/data/.gitignore
@@ -4,4 +4,6 @@ name_whitespace.inv
 no_objects.inv
 role_colon.inv
 skipped_lines.inv
+skipped_lines_lf.inv
+skipped_lines_crlf.inv
 valid.inv

--- a/tests/data/Makefile
+++ b/tests/data/Makefile
@@ -1,4 +1,4 @@
-files = valid.inv skipped_lines.inv invalid_object.inv no_objects.inv name_whitespace.inv role_colon.inv
+files = valid.inv skipped_lines.inv skipped_lines_lf.inv skipped_lines_crlf.inv invalid_object.inv no_objects.inv name_whitespace.inv role_colon.inv
 
 ifeq (, $(shell which pigz 2> /dev/null))
 	ZLIB_COMPRESS = ./zlib-compress

--- a/tests/data/skipped_lines_crlf.data
+++ b/tests/data/skipped_lines_crlf.data
@@ -1,0 +1,3 @@
+
+# This is not an object.
+valid std:object 1 line -

--- a/tests/data/skipped_lines_crlf.header
+++ b/tests/data/skipped_lines_crlf.header
@@ -1,0 +1,4 @@
+# Sphinx inventory version 2
+# Project: CLUB1
+# Version: main
+# The remainder of this file is compressed using zlib.

--- a/tests/data/skipped_lines_lf.data
+++ b/tests/data/skipped_lines_lf.data
@@ -1,0 +1,3 @@
+
+# This is not an object.
+valid std:object 1 line -

--- a/tests/data/skipped_lines_lf.header
+++ b/tests/data/skipped_lines_lf.header
@@ -1,0 +1,4 @@
+# Sphinx inventory version 2
+# Project: CLUB1
+# Version: main
+# The remainder of this file is compressed using zlib.


### PR DESCRIPTION
Use rtrim with only `\n` and `\r` characters instead of substr when displaying error messages.
The rest of the code was already supporting Windows EOL.
