### PR TITLE
fix: crash with zero length location in object

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,15 @@
 
 ## [unreleased]
 
+### Fixed
+
+- Fix a crash with zero length location in an object line ([#7]).
+
 ### Added
 
 - Include the Changelog in the documentation.
+
+[#7]: https://github.com/club-1/sphinx-inventory-parser/pull/7
 
 ## [v1.1.0] - 2023-05-14
 

--- a/src/SphinxInventoryParser.php
+++ b/src/SphinxInventoryParser.php
@@ -227,7 +227,7 @@ class SphinxInventoryParser
 			}
 			array_shift($matches);
 			list($name, $domain, $role, $priority, $location, $displayName) = $matches;
-			if ($location[-1] == '$') {
+			if (strlen($location) > 0 && $location[-1] == '$') {
 				$location = substr($location, 0, -1) . $name;
 			}
 			$uri  = $baseURI . $location;

--- a/tests/SphinxInventoryParserTest.php
+++ b/tests/SphinxInventoryParserTest.php
@@ -43,6 +43,10 @@ final class SphinxInventoryParserTest extends TestCase
 				'name domain:role:colon 1 doc.html#role-colon-$ -',
 				['name', 'domain', 'role:colon', 1, 'doc.html#role-colon-name', 'name']
 			],
+			'zero lenth location' => [
+				'name domain:role 1  dispname',
+				['name', 'domain', 'role', 1, '', 'dispname']
+			],
 		];
 	}
 


### PR DESCRIPTION
Fix a crash when location have zero length, [which can happen](https://sphobjinv.readthedocs.io/en/stable/syntax.html#uri) and add a regression test.

Found thanks to [nikic/PHP-Fuzzer](https://github.com/nikic/PHP-Fuzzer).