### PR TITLE
Decompress the stream only in parseObjectsV2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@
 
 - Stream reading errors in `parseObjects()` and `parseHeader()` are silenced,
   an exception is still thrown but it now contains the error message.
+- Set Zlib inflate stream filter in `parseObjects()` instead of `parseHeader()`.
+  This allows to at least correctly parse the header even if the rest is
+  corrupted ([#10]).
 
 ### Removed
 
@@ -18,6 +21,7 @@
 
 [nikic/PHP-Fuzzer]: https://github.com/nikic/PHP-Fuzzer
 [#6]: https://github.com/club-1/sphinx-inventory-parser/pull/6
+[#10]: https://github.com/club-1/sphinx-inventory-parser/pull/10
 
 ## [v1.1.1] - 2024-01-13
 

--- a/tests/SphinxInventoryParserTest.php
+++ b/tests/SphinxInventoryParserTest.php
@@ -35,7 +35,7 @@ final class SphinxInventoryParserTest extends TestCase
 	{
 		$object = new SphinxObject(...$objectArray);
 		$stream = fopen('php://memory','r+');
-		fwrite($stream, $objectLine);
+		fwrite($stream, gzcompress($objectLine));
 		rewind($stream);
 		$parser = new SphinxInventoryParser($stream);
 		$header = new SphinxInventoryHeader(2);
@@ -77,7 +77,7 @@ final class SphinxInventoryParserTest extends TestCase
 	public function testInvalidObjectsV2(string $objectLine): void
 	{
 		$stream = fopen('php://memory','r+');
-		fwrite($stream, $objectLine);
+		fwrite($stream, gzcompress($objectLine));
 		rewind($stream);
 		$parser = new SphinxInventoryParser($stream);
 		$header = new SphinxInventoryHeader(2);

--- a/tests/fuzz/parseObjectsV2/target.php
+++ b/tests/fuzz/parseObjectsV2/target.php
@@ -28,7 +28,7 @@ use Club1\SphinxInventoryParser\SphinxInventoryParser;
 /** @var PhpFuzzer\Config $config */
 $config->setTarget(function(string $input) {
 	$stream = fopen('php://memory','r+');
-	fwrite($stream, $input);
+	fwrite($stream, gzcompress($input, 0));
 	rewind($stream);
 
 	$parser = new SphinxInventoryParser($stream);


### PR DESCRIPTION
This allows to at least correctly parse the Header even if the rest is corrupted.
