### PR TITLE
Throw an exception when $url is an empty string

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,8 +9,11 @@
 ### Changed
 
 - Simplify error handling in `parseFromDoc()`.
+- Throw an exception in `parseFromDoc()` when `$url` is an empty string, instead
+  of emitting a warning and continuing ([#15]).
 
 [#14]: https://github.com/club-1/sphinx-inventory-parser/pull/14
+[#15]: https://github.com/club-1/sphinx-inventory-parser/pull/15
 
 ## [v1.2.0] - 2024-01-25
 

--- a/src/SphinxInventoryParser.php
+++ b/src/SphinxInventoryParser.php
@@ -59,6 +59,9 @@ class SphinxInventoryParser
 	 * @throws RuntimeException		If the stream can not be open.
 	 */
 	public static function parseFromDoc(string $url, string $path = 'objects.inv'): SphinxInventory {
+		if (strlen($url) == 0) {
+			throw new InvalidArgumentException('$url cannot be empty');
+		}
 		if ($url[-1] != '/') {
 			$url .= '/';
 		}

--- a/tests/SphinxInventoryParserTest.php
+++ b/tests/SphinxInventoryParserTest.php
@@ -273,11 +273,11 @@ final class SphinxInventoryParserTest extends TestCase
 	/**
 	 * @dataProvider parseFromDocExceptionsProvider
 	 */
-	public function testParseFromDocException(string $inv, string $class, string $msg): void
+	public function testParseFromDocException(string $url, string $inv, string $class, string $msg): void
 	{
 		$this->expectException($class);
 		$this->expectExceptionMessage($msg);
-		SphinxInventoryParser::parseFromDoc('tests/data', $inv);
+		SphinxInventoryParser::parseFromDoc($url, $inv);
 	}
 
 	/**
@@ -286,13 +286,20 @@ final class SphinxInventoryParserTest extends TestCase
 	public function parseFromDocExceptionsProvider(): array
 	{
 		return [
-			["non_existing.inv",
+			'non-existing inventory' => [
+				'tests/data', 'non_existing.inv',
 				RuntimeException::class,
 				"could not open file: fopen(tests/data/non_existing.inv): "
 			],
-			["invalid_object.inv",
+			'invalid object inventory' => [
+				'tests/data', 'invalid_object.inv',
 				UnexpectedValueException::class,
 				"object string did not match pattern: ' domain:role 1 location dispname'"
+			],
+			'empty url' => [
+				'', 'valid.inv',
+				InvalidArgumentException::class,
+				'$url cannot be empty'
 			],
 		];
 	}


### PR DESCRIPTION
- Throw an exception when $url is an empty string
- Update parseFromDoc tests for empty url (abda372)
