### PR TITLE
ci: add new linkcheck workflow

### DIFF
--- a/.github/workflows/linkcheck.yml
+++ b/.github/workflows/linkcheck.yml
@@ -1,0 +1,24 @@
+name: linkcheck
+
+on:
+  schedule:
+    - cron: '33 3 * * 1'
+  pull_request:
+    branches: [main]
+
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+jobs:
+  all:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install Python dependencies
+        run: pip install -r docs/requirements.txt
+      - name: Install PHP dependencies
+        run: make vendor
+      - name: Prepare docs
+        run: make
+      - name: Run linkcheck
+        run: make docs BUILDER=linkcheck


### PR DESCRIPTION
This workflow it run on each pull request to main and every monday at 3:33, it verifies all external links to make sure they are not broken.